### PR TITLE
fix: run MLX inference in fp16 end-to-end, matching the PT reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This fork must stay trivially mergeable with upstream:
 
 - **Never modify upstream PyTorch files.** All MLX code lives in additive `*_mlx.py` files (or `*_mlx/` packages) next to the upstream file they mirror, with the same module/class/method structure so a side-by-side diff shows only PyTorch↔MLX op substitutions.
 - Config defaults must match the PyTorch reference exactly. Any deviation hides a port bug — match first, optimize only for a documented framework constraint (e.g. Metal command-buffer budget, handled via tiling).
+- **Iso-upstream includes the runtime execution config, not just code structure**: dtype policy (upstream runs both stages in fp16 end-to-end), device semantics, scheduler precision islands. MLX type promotion is stricter than PyTorch's (0-d arrays are not weak like torch scalar tensors), so a single fp32 constant silently upcasts everything downstream — verify actual kernel dtypes with `smeltr record` + op summary after any pipeline change, don't trust the code diff.
 - Keep `git fetch upstream` clean: the only tolerated upstream edits are the README MLX section and appended MLX deps in `hy3dshape/requirements.txt`.
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Defaults match the PyTorch reference config exactly, including `texture_size=409
 | INT8      | 3.0 GB   | ~6 GB       | 16 GB+          |
 | INT4      | 1.6 GB   | ~4 GB       | 16 GB           |
 
-Stage 2 (paint) adds ~6 GB peak for the UNet + VAE + DINOv2 at fp32.
+Stage 2 (paint) adds a few GB peak for the UNet + VAE + DINOv2, all running in fp16 like the PyTorch reference.
 
 ### Scope
 

--- a/hy3dpaint/hunyuanpaintpbr_mlx/dino_mlx.py
+++ b/hy3dpaint/hunyuanpaintpbr_mlx/dino_mlx.py
@@ -180,7 +180,9 @@ class DINOv2MLX(nn.Module):
             align_corners=False,
         )
         patch_new = pt_new.permute(0, 2, 3, 1).numpy().reshape(1, g_new * g_new, -1)
-        new_pos = mx.array(np.concatenate([cls_np, patch_new], axis=1))
+        new_pos = mx.array(
+            np.concatenate([cls_np, patch_new], axis=1)
+        ).astype(self.pos_embed.dtype)
         cache[num_patches_in] = new_pos
         self._pos_embed_cache = cache
         return new_pos

--- a/hy3dpaint/hunyuanpaintpbr_mlx/inference.py
+++ b/hy3dpaint/hunyuanpaintpbr_mlx/inference.py
@@ -117,7 +117,8 @@ def generate_multiview_pbr(
             )
             arr = np.array(pil).astype(np.float32) / 255.0
             arrays.append(arr)
-        batch = mx.array(np.stack(arrays))  # (N, H, W, 3)
+        # fp16 like the PT reference (pipeline.py:245 sends inputs .half())
+        batch = mx.array(np.stack(arrays)).astype(mx.float16)  # (N, H, W, 3)
         # vae.encode already multiplies by self.scaling_factor internally;
         # do NOT re-multiply (was double-scaling latents to ~0.033 of the
         # expected magnitude, making ref_latents and z_normal/z_pos
@@ -157,7 +158,7 @@ def generate_multiview_pbr(
     # HF DINOv2 produces at 224 input — the distribution attn_dino's
     # to_k / to_v were trained against. HF DINO bridge OOMs 32 GB in
     # both fp32 and fp16.
-    dino_in = preprocess_for_dino(ref_u8)
+    dino_in = preprocess_for_dino(ref_u8).astype(mx.float16)
     dino_feat = model.dino(dino_in)  # (1, 1370, 1536)
     # Separate CLS + patch grid, avg-pool 37x37 -> 16x16
     import math as _math
@@ -234,7 +235,8 @@ def generate_multiview_pbr(
     view_scales = [_cam_mapping(a) for a in camera_azims]
     # Repeat for materials: [albedo_scales, mr_scales]
     view_scale_flat = np.array(view_scales * n_pbr, dtype=np.float32)
-    view_scale = mx.array(view_scale_flat)[:, None, None, None]  # (12, 1, 1, 1)
+    # fp16 so the CFG combine below stays in the model dtype
+    view_scale = mx.array(view_scale_flat)[:, None, None, None].astype(mx.float16)  # (12, 1, 1, 1)
 
     # ------------------------------------------------------------------
     # 5. Prepare condition latents for concat
@@ -246,7 +248,9 @@ def generate_multiview_pbr(
     # ------------------------------------------------------------------
     # 6. Denoising loop
     # ------------------------------------------------------------------
-    latents = mx.random.normal((n_pbr * n_views, latent_size, latent_size, 4))
+    latents = mx.random.normal(
+        (n_pbr * n_views, latent_size, latent_size, 4), dtype=mx.float16
+    )
     model.scheduler.set_timesteps(num_inference_steps)
 
     print(f"  Denoising ({num_inference_steps} steps, {n_views} views, CFG={guidance_scale})...")

--- a/hy3dpaint/hunyuanpaintpbr_mlx/load_model.py
+++ b/hy3dpaint/hunyuanpaintpbr_mlx/load_model.py
@@ -285,15 +285,12 @@ class HunyuanPaintModelMLX:
         del vae_w
 
         # --- DINOv2 ---
-        # Weights ship as fp16. With 40 transformer blocks the per-op
-        # quantisation error accumulates (output diverges ~5x vs fp32 HF on
-        # the same input — measured). Upcast to fp32 for DINO: the model is
-        # small enough (~1.2 GB weights) that the extra memory is fine, and
-        # the reference conditioning quality depends on clean features.
+        # Run in fp16 like the PT reference (utils/multiview_utils.py:57
+        # casts Dino_v2 to torch.float16). MLX fp16 gemm/norm kernels
+        # accumulate in fp32, matching CUDA fp16 semantics.
         print("Loading DINOv2...")
         dino = DINOv2MLX()
-        dino_w = {k: v.astype(mx.float32) for k, v in
-                  mx.load(str(weights_dir / "paint_dino.safetensors")).items()}
+        dino_w = dict(mx.load(str(weights_dir / "paint_dino.safetensors")))
         dino.load_weights(list(dino_w.items()))
         del dino_w
 
@@ -385,6 +382,16 @@ class HunyuanPaintModelMLX:
         del unet_w, stripped, stripped_dual
 
         scheduler = UniPCMultistepSchedulerMLX()
+
+        # PT reference loads the whole paint pipeline with
+        # torch_dtype=torch.float16 (utils/multiview_utils.py:46); mirror
+        # it so any fp32 straggler in the checkpoints is downcast and the
+        # forward runs in fp16 end-to-end.
+        for module in (unet, vae, dino, image_proj):
+            module.set_dtype(mx.float16)
+        if unet_dual is not None:
+            unet_dual.set_dtype(mx.float16)
+        learned = {k: v.astype(mx.float16) for k, v in learned.items()}
 
         model = HunyuanPaintModelMLX(
             unet=unet,

--- a/hy3dpaint/hunyuanpaintpbr_mlx/unet/attn_processor_mlx.py
+++ b/hy3dpaint/hunyuanpaintpbr_mlx/unet/attn_processor_mlx.py
@@ -105,8 +105,14 @@ class RotaryEmbedding:
         out_even = x_even * cos_half - x_odd * sin_half
         out_odd = x_odd * cos_half + x_even * sin_half
 
-        # Interleave back: stack on last dim then flatten
-        return mx.stack([out_even, out_odd], axis=-1).reshape(x.shape)
+        # Interleave back: stack on last dim then flatten. The fp32 cos/sin
+        # promote the products to fp32; cast back to the input dtype like
+        # PT's apply_rotary_emb (`(x.float() * cos + ...).to(x.dtype)`).
+        return (
+            mx.stack([out_even, out_odd], axis=-1)
+            .reshape(x.shape)
+            .astype(x.dtype)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/hy3dpaint/hunyuanpaintpbr_mlx/unet/unet_mlx.py
+++ b/hy3dpaint/hunyuanpaintpbr_mlx/unet/unet_mlx.py
@@ -179,6 +179,11 @@ class UNet2DConditionModelMLX(nn.Module):
         if timestep.ndim == 0:
             timestep = mx.expand_dims(timestep, 0)
         t_emb = get_timestep_embedding(timestep, self.time_proj_dim)
+        # Cast the fp32 sinusoidal embedding to the sample dtype before the
+        # MLP, matching diffusers UNet2DConditionModel
+        # (`t_emb = t_emb.to(dtype=sample.dtype)`); otherwise the fp32 temb
+        # would upcast every ResNet block through the additive path.
+        t_emb = t_emb.astype(sample.dtype)
         emb = self.time_embedding(t_emb)  # (B, time_embed_dim)
 
         # Broadcast for batch

--- a/hy3dpaint/utils/image_super_utils_mlx.py
+++ b/hy3dpaint/utils/image_super_utils_mlx.py
@@ -212,6 +212,9 @@ class imageSuperNetMLX:
             raise ValueError(f"Unsupported weight format: {weights_path}")
 
         self.model.load_weights(list(weights.items()))
+        # PT reference runs RealESRGAN with half=True
+        # (utils/image_super_utils.py:33) — mirror in fp16.
+        self.model.set_dtype(mx.float16)
         mx.eval(self.model.parameters())
 
     def __call__(self, image: Image.Image) -> Image.Image:
@@ -223,10 +226,11 @@ class imageSuperNetMLX:
         Returns:
             Super-resolved PIL Image (RGB).
         """
-        # Convert PIL Image to NHWC float32 array normalized to [0, 1]
+        # Convert PIL Image to NHWC array normalized to [0, 1], fp16 like
+        # the PT reference (half=True)
         img_np = np.array(image).astype(np.float32) / 255.0
         # Add batch dimension: (H, W, C) -> (1, H, W, C)
-        img_mx = mx.array(img_np[np.newaxis, ...])
+        img_mx = mx.array(img_np[np.newaxis, ...]).astype(mx.float16)
 
         # Run inference
         output = self.model(img_mx)

--- a/hy3dshape/hy3dshape/models/conditioner_mlx.py
+++ b/hy3dshape/hy3dshape/models/conditioner_mlx.py
@@ -350,8 +350,10 @@ class ImageEncoder(nn.Module):
         Returns:
             Normalized image tensor.
         """
-        mean = mx.array(self.MEAN).reshape(1, 1, 1, 3)
-        std = mx.array(self.STD).reshape(1, 1, 1, 3)
+        # Cast stats to the image dtype (torchvision Normalize keeps the
+        # input dtype, so a half input stays half in the PT reference).
+        mean = mx.array(self.MEAN).reshape(1, 1, 1, 3).astype(image.dtype)
+        std = mx.array(self.STD).reshape(1, 1, 1, 3).astype(image.dtype)
         return (image - mean) / std
 
     def __call__(self, image: mx.array, value_range=(-1, 1)) -> mx.array:
@@ -387,7 +389,10 @@ class ImageEncoder(nn.Module):
         Returns:
             Zero tensor of shape (batch_size, num_patches, hidden_size).
         """
-        return mx.zeros((batch_size, self.num_patches, self.hidden_size))
+        return mx.zeros(
+            (batch_size, self.num_patches, self.hidden_size),
+            dtype=self.layernorm.weight.dtype,
+        )
 
     @classmethod
     def from_pretrained(cls, weights_path: str, config: dict) -> "ImageEncoder":

--- a/hy3dshape/hy3dshape/pipeline_mlx.py
+++ b/hy3dshape/hy3dshape/pipeline_mlx.py
@@ -47,11 +47,19 @@ class ShapePipeline:
         dit: HunYuanDiTPlain,
         vae: ShapeVAEDecoder,
         scheduler: FlowMatchEulerDiscreteScheduler,
+        dtype: mx.Dtype = mx.float16,
     ):
         self.image_encoder = image_encoder
         self.dit = dit
         self.vae = vae
         self.scheduler = scheduler
+        # PT reference runs the whole pipeline in fp16 (pipelines.py
+        # dtype=torch.float16 + self.to(device, dtype)); mirror it by
+        # casting every floating-point weight and driving activations
+        # in the same dtype.
+        self.dtype = dtype
+        for module in (self.image_encoder, self.dit, self.vae):
+            module.set_dtype(dtype)
 
     def preprocess_image(self, image: Union[str, Image.Image, mx.array]) -> mx.array:
         """Load and preprocess an image for DINOv2.
@@ -82,9 +90,10 @@ class ShapePipeline:
             target_size = self.image_encoder.image_size
             image = image.resize((target_size, target_size), Image.BILINEAR)
 
-            # Convert to numpy then mx array: (H, W, 3) float32 in [-1, 1]
+            # Convert to numpy then mx array: (H, W, 3) in [-1, 1],
+            # cast to the pipeline dtype (PT: image.to(device, self.dtype))
             arr = np.array(image, dtype=np.float32) / 127.5 - 1.0
-            return mx.array(arr[None])  # (1, H, W, 3)
+            return mx.array(arr[None]).astype(self.dtype)  # (1, H, W, 3)
 
         # Already mx.array
         return image
@@ -130,7 +139,9 @@ class ShapePipeline:
 
         # 3. Prepare latents
         num_latents, latent_dim = self.vae.latent_shape
-        latents = mx.random.normal((1, num_latents, latent_dim))
+        latents = mx.random.normal(
+            (1, num_latents, latent_dim), dtype=self.dtype
+        )
         _materialize(latents)
 
         # 4. Set up scheduler with sigmas from 0 to 1 (matching original pipeline)
@@ -166,8 +177,10 @@ class ShapePipeline:
                 pred_cond, pred_uncond = noise_pred[:1], noise_pred[1:]
                 noise_pred = pred_uncond + guidance_scale * (pred_cond - pred_uncond)
 
-            # Euler step
-            latents = self.scheduler.step(noise_pred, t, latents)
+            # Euler step. The scheduler's fp32 sigmas promote the update to
+            # fp32; cast back like diffusers FlowMatchEulerDiscreteScheduler
+            # (upcast for precision, return prev_sample in model dtype).
+            latents = self.scheduler.step(noise_pred, t, latents).astype(self.dtype)
             _materialize(latents)
 
         # 6. Free DiT to save memory
@@ -197,6 +210,7 @@ class ShapePipeline:
     def from_pretrained(
         cls,
         weights_source: str = "dgrauet/hunyuan3d-2.1-mlx",
+        dtype: mx.Dtype = mx.float16,
     ) -> "ShapePipeline":
         """Load all components from converted weights.
 
@@ -277,4 +291,5 @@ class ShapePipeline:
             dit=dit,
             vae=vae,
             scheduler=scheduler,
+            dtype=dtype,
         )


### PR DESCRIPTION
Closes #2 — see the issue comment for the full analysis. The PT reference runs both stages in fp16 end-to-end; the MLX port ran everything in fp32 via silent type promotion.

Changes: pipeline-level dtype plumbing (Stage 1 `dtype` param mirroring `pipelines.py`), fp16 latents/inputs, scheduler-output recast (diffusers semantics), DINO back to fp16 (the documented 5x divergence does not reproduce: cosine 0.999998 vs fp32 on real weights), missing diffusers timestep-embedding cast in the paint UNet, RoPE output recast, RealESRGAN fp16 (`half=True` upstream).

Verified: 108 unit tests green; reduced e2e smoke (Stage 1 mesh + Stage 2 paint) finite and coherent; smeltr shows all top kernels float16 with upcast copies gone. Companion fix: dgrauet/mlx-arsenal#45 (MoE routing buffers were default-fp32 — requires an arsenal release, then bump `mlx-arsenal` in `hy3dshape/requirements.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DecFp2rexC8wEWef4Vg2ez