### PR TITLE
chore: require mlx-arsenal>=0.10.1 for the MoE dtype fix

### DIFF
--- a/hy3dshape/requirements.txt
+++ b/hy3dshape/requirements.txt
@@ -41,6 +41,6 @@ onnxruntime
 
 # MLX port
 mlx>=0.31.0
-mlx-arsenal>=0.2.1
+mlx-arsenal>=0.10.1
 safetensors
 Pillow


### PR DESCRIPTION
Completes the fp16 rollout (#2, #4): mlx-arsenal 0.10.1 ships the MoE dtype-preservation fix (dgrauet/mlx-arsenal#45). Verified on the published wheel: 108 unit tests green, smeltr Stage 1 profile shows all top kernels float16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DecFp2rexC8wEWef4Vg2ez