### PR TITLE
fix(paint): round super-res output like RealESRGANer, document BGR non-emulation

### DIFF
--- a/docs/forward_pass.md
+++ b/docs/forward_pass.md
@@ -234,10 +234,22 @@ view, eliminated UV seam cracks, and matched PT quality.
 
 **Rule**: the first working version must match the reference config
 exactly. Only deviate when there is a target-framework constraint
-documented in code (e.g. `texture_size=2048` because the MLX Metal
-rasterizer lacks tiling and times out on the command buffer at
-PT's 4096). Every other config-level "knob" is almost certainly
-a port bug waiting to be found.
+documented in code (e.g. the UV-space rasterizer processes the atlas in
+tiles so PT's `texture_size=4096` fits the Metal command-buffer budget).
+Every other config-level "knob" is almost certainly a port bug waiting
+to be found.
+
+### Documented deviations from upstream behavior
+
+- **RealESRGAN channel order**: upstream feeds RGB (`np.array(PIL)`)
+  into `RealESRGANer.enhance()`, which assumes cv2-BGR input and does
+  `cvtColor(BGR2RGB)` before the net and the inverse swap after — so
+  the reference super-resolves each view with R and B swapped, then
+  restores the order. This is an upstream bug (the net is trained on
+  RGB). The MLX port feeds the net proper RGB and does NOT emulate the
+  double swap; visible impact is minimal because the net is nearly
+  color-symmetric, but pixel-exact parity against PT's SR output is
+  not expected. Decision 2026-07-17.
 
 ## Critical invariants (learned the hard way)
 

--- a/hy3dpaint/utils/image_super_utils_mlx.py
+++ b/hy3dpaint/utils/image_super_utils_mlx.py
@@ -238,5 +238,7 @@ class imageSuperNetMLX:
 
         # Convert back to PIL Image
         output_np = np.array(output[0])  # Remove batch dim
-        output_np = np.clip(output_np * 255.0, 0, 255).astype(np.uint8)
+        # Round like RealESRGANer.enhance ((output * 255.0).round()); a
+        # plain astype would truncate and shift ~half the pixels by 1/255.
+        output_np = np.clip(output_np * 255.0, 0, 255).round().astype(np.uint8)
         return Image.fromarray(output_np)


### PR DESCRIPTION
Two RealESRGAN parity items from the iso-upstream review:

1. Output quantization now rounds ((output*255).round()) like `RealESRGANer.enhance()` instead of truncating — up to 1/255 shift on ~half the texture pixels before.
2. `docs/forward_pass.md` gains a 'Documented deviations' section recording the decision NOT to emulate upstream's channel-swap bug (RGB fed into a BGR-assuming enhance()), plus a refresh of the stale texture_size example.

e2e validation run in progress; result will be posted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DecFp2rexC8wEWef4Vg2ez